### PR TITLE
fix: conversion compatibility

### DIFF
--- a/internal/clients/team2/agenttwo.go
+++ b/internal/clients/team2/agenttwo.go
@@ -62,8 +62,8 @@ type Vector struct {
 }
 
 func forcesToVectorConversion(force utils.Forces) Vector {
-	xCoordinate := force.Pedal * float64(math.Cos(float64(math.Pi*force.Turning)))
-	yCoordinate := force.Pedal * float64(math.Sin(float64(math.Pi*force.Turning)))
+	xCoordinate := force.Pedal * float64(math.Cos(float64(math.Pi*force.Turning.SteeringForce)))
+	yCoordinate := force.Pedal * float64(math.Sin(float64(math.Pi*force.Turning.SteeringForce)))
 
 	newVector := Vector{X: xCoordinate, Y: yCoordinate}
 	return newVector


### PR DESCRIPTION
Previously turning is defined float64. It has been changed in the upstream repo, thus changing to make it compatible.